### PR TITLE
Player Propel Mechanic

### DIFF
--- a/Assets/Prefabs/Needle/Needle.prefab
+++ b/Assets/Prefabs/Needle/Needle.prefab
@@ -150,7 +150,7 @@ Rigidbody2D:
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
-  m_Mass: 1
+  m_Mass: 0.5
   m_LinearDrag: 0
   m_AngularDrag: 0.05
   m_GravityScale: 0
@@ -206,7 +206,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 69b9d49cd0fbc4380a42c75b394294ed, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  throwingForce: 700
   recallSpeed: 10
 --- !u!114 &1345549503420055086
 MonoBehaviour:

--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -196,6 +196,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   needle: {fileID: 0}
+  throwingForce: 350
 --- !u!114 &4292287585466077967
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -210,3 +211,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   needleUnlocked: 1
   needlePrefab: {fileID: 77980522465328453, guid: fc441add8207f419ea8ae809881e8baf, type: 3}
+  propelUnlocked: 1

--- a/Assets/Scenes/DummyScene2.unity
+++ b/Assets/Scenes/DummyScene2.unity
@@ -150,7 +150,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -8.5, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 10, z: 1}
+  m_LocalScale: {x: 1, y: 20, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 695702567}
@@ -280,7 +280,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 8.5, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 10, z: 1}
+  m_LocalScale: {x: 1, y: 20, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 695702567}
@@ -443,7 +443,7 @@ Camera:
   far clip plane: 1000
   field of view: 60
   orthographic: 1
-  orthographic size: 5
+  orthographic size: 10
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -527,7 +527,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &782167836
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Needle/NeedleMovement.cs
+++ b/Assets/Scripts/Needle/NeedleMovement.cs
@@ -6,7 +6,6 @@ using static UnityEngine.GraphicsBuffer;
 
 public class NeedleMovement : MonoBehaviour
 {
-    public float throwingForce = 700.0f;
     public float recallSpeed = 10.0f;
 
     NeedleState needleState;
@@ -30,7 +29,7 @@ public class NeedleMovement : MonoBehaviour
     }
 
     //throw needle in its current direction
-    public void ThrowNeedle()
+    public void ThrowNeedle(float throwingForce)
     {
         if (!needleState.IsEquipped())
         {

--- a/Assets/Scripts/Player/PlayerJump.cs
+++ b/Assets/Scripts/Player/PlayerJump.cs
@@ -10,7 +10,7 @@ public class PlayerJump : MonoBehaviour
     Rigidbody2D rb;
     CapsuleCollider2D col;
 
-
+    PlayerNeedle playerNeedle;
 
     // Start is called before the first frame update
     void Start()
@@ -18,6 +18,7 @@ public class PlayerJump : MonoBehaviour
         rb = this.GetComponent<Rigidbody2D>();
         col = this.GetComponent<CapsuleCollider2D>();
 
+        playerNeedle = this.GetComponent<PlayerNeedle>();
     }
 
     // Update is called once per frame
@@ -33,9 +34,11 @@ public class PlayerJump : MonoBehaviour
                 rb.AddForce(Vector3.up * jumpPower);
 
             }
+
+            //reset throwing force if player is grounded so they can propel at max force again
+            playerNeedle.ResetThrowingForce();
         }
 
-        
     }
 
     //checks if player is grounded by performing a raycast to see if there's a ground right below them
@@ -46,6 +49,7 @@ public class PlayerJump : MonoBehaviour
         // A bit below the bottom
         float fullDistance = col.bounds.extents.y + 0.1f - col.bounds.extents.x;
 
-        return Physics2D.CapsuleCast(this.transform.position, col.size, col.direction, 0, Vector2.down, fullDistance, groundWallLayer);
+        //Note: did 95% of collider's size in case the side's are already touching walls
+        return Physics2D.CapsuleCast(this.transform.position, col.size * 0.95f, col.direction, 0, Vector2.down, fullDistance, groundWallLayer);
     }
 }

--- a/Assets/Scripts/Player/PlayerNeedle.cs
+++ b/Assets/Scripts/Player/PlayerNeedle.cs
@@ -7,10 +7,25 @@ public class PlayerNeedle : MonoBehaviour
     //TODO: player needs reference to needle that they wield; temporarily done by public reference
     public NeedleMovement needle;
 
+    PlayerPowerupInventory playerPowerupInventory;
+    NeedleState needleState;
+
+    //dictates force that player throws the needle which will consequently propel player mid-air
+    public float throwingForce = 700.0f;
+    //the actual max throwing force (throwingForce can vary so we track an original max value)
+    float maxThrowingForce;
+
+    Rigidbody2D rigid;
+
     // Start is called before the first frame update
     void Start()
     {
-        
+        playerPowerupInventory = this.GetComponent<PlayerPowerupInventory>();
+        needleState = needle.GetComponent<NeedleState>();
+
+        maxThrowingForce = throwingForce;
+
+        rigid = this.GetComponent<Rigidbody2D>();
     }
 
     // Update is called once per frame
@@ -18,6 +33,20 @@ public class PlayerNeedle : MonoBehaviour
     {
         //TODO: consider using infrastructure for keybinds/controls instead of just fixed keycodes
         //checks whether to throw or recall needle based on input
+
+        //LMB to throw/recall needle depending on if needle is equipped or not
+        if (Input.GetKeyDown(KeyCode.Mouse0))
+        {
+            if (needleState.IsEquipped())
+            {
+                ThrowNeedle();
+            }
+            else
+            {
+                RecallNeedle();
+            }
+        }
+        /*
         if (Input.GetKeyDown(KeyCode.Mouse0))
         {
             ThrowNeedle();
@@ -26,15 +55,49 @@ public class PlayerNeedle : MonoBehaviour
         {
             RecallNeedle();
         }
+        */
+        //RMB to throw needle but also, if player is mid-air, player is propelled in opposite direction at same time
+        if (Input.GetKeyDown(KeyCode.Mouse1))
+        {
+            if (needleState.IsEquipped() && !this.GetComponent<PlayerJump>().IsGrounded())
+            {
+                PropelNeedle();
+            }
+        }
+        
     }
 
     public void ThrowNeedle()
     {
-        needle.ThrowNeedle();
+        needle.ThrowNeedle(throwingForce);
     }
 
     public void RecallNeedle()
     {
         needle.RecallNeedle();
+    }
+
+
+    public void PropelNeedle()
+    {
+        ThrowNeedle();
+
+        //record direction that needle is thrown in relative to player
+        Vector2 thrownDirection = needle.Direction(this.transform.position, needle.transform.position); //NOTE: maybe use mouseCursor position instead of needle
+
+        //reset velocity to zero before being propelled
+        rigid.velocity = Vector3.zero;
+        //now actually propel player in opposite direction of thrown needle
+        rigid.AddForce(thrownDirection * throwingForce * (-1));
+
+        //when throwing in midair, the throwing/propelling power is weakened (as a balance measure against doing it consecutively)
+        //reverts when on ground. for the revert change code, refer to PlayerJump
+        throwingForce *= 0.8f;
+    }
+
+    //reset throwing force back to max value
+    public void ResetThrowingForce()
+    {
+        throwingForce = maxThrowingForce;
     }
 }

--- a/Assets/Scripts/Player/PlayerPowerupInventory.cs
+++ b/Assets/Scripts/Player/PlayerPowerupInventory.cs
@@ -8,6 +8,8 @@ public class PlayerPowerupInventory : MonoBehaviour
     public bool needleUnlocked = true;
     public GameObject needlePrefab;
 
+    public bool propelUnlocked = true;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -26,5 +28,10 @@ public class PlayerPowerupInventory : MonoBehaviour
     void Update()
     {
         
+    }
+
+    public bool HasPropelUnlocked()
+    {
+        return propelUnlocked;
     }
 }


### PR DESCRIPTION
-Revised needle's movement script. Originally it had a throwingForce public value but now that value will be based in the player's PlayerNeedle script (so when player does throw, it tells needle how much the throwingForce is). -Added a bool for the propel mechanic in the powerup inventory script. 
-Revised player controls so that LMB is for throwing/recalling accordingly. And RMB does a throw mid-air which also propels player in opposite direction (need to reconsider control scheme for this).
-Also let the throwingForce decrease each time it's thrown mid-air (will reset when player is grounded) to ensure player doesn't abuse verticality -Halved mass of needle so that the throw makes needle go faster relative to player's propelled speed.

NOTE: Heavily advise readjusting player movement & jump to be smooth so it determines placements of platforms for precision for the future. Also should adjust/finalize mass & throwing force for player + needle so we get a good balance for their speeds.
Also should consider making needle be affected by gravity while thrown.