### PR TITLE
Dialogue Locking Movement

### DIFF
--- a/Assets/Scripts/Characters/DialogManager.cs
+++ b/Assets/Scripts/Characters/DialogManager.cs
@@ -150,10 +150,12 @@ public class DialogManager : MonoBehaviour
         if (locking)
         {
             // TODO - disable player movement and similar
+            PlayerRun.receivePlayerMovementInput = false;
         }
         else
         {
             // TODO - enable player movement and similar
+            PlayerRun.receivePlayerMovementInput = true;
 
             RefreshAllInteractors();
         }

--- a/Assets/Scripts/Player/PlayerJump.cs
+++ b/Assets/Scripts/Player/PlayerJump.cs
@@ -24,8 +24,8 @@ public class PlayerJump : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-
-        if (IsGrounded())
+        //only consider jumping as an option if player is allowed to receive player movement inputs & is currently grounded
+        if (PlayerRun.receivePlayerMovementInput && IsGrounded())
         {
             //if grounded, you can jump with spacebar
             if (Input.GetKeyDown(KeyCode.Space))

--- a/Assets/Scripts/Player/PlayerRun.cs
+++ b/Assets/Scripts/Player/PlayerRun.cs
@@ -9,6 +9,7 @@ public class PlayerRun : MonoBehaviour
     public float acceleration = 1.0f; //decides how quickly player increases speed
     public float decceleration = 2.0f; //decides how quickly player slows down when too fast or wanting to stop
 
+    public static bool receivePlayerMovementInput = true; //tells us if player should receive inputs to move or not
 
     Rigidbody2D rb;
     float targetXVelocity = 0.0f;
@@ -38,13 +39,17 @@ public class PlayerRun : MonoBehaviour
     {
         xDirectionInput = 0;
 
-        if (Input.GetKey(KeyCode.A))
+        //only update target velocity direction if player is allowed to receive movement inputs; otherwise its goal is zero-velocity
+        if (receivePlayerMovementInput)
         {
-            xDirectionInput -= 1;
-        }
-        if (Input.GetKey(KeyCode.D))
-        {
-            xDirectionInput += 1;
+            if (Input.GetKey(KeyCode.A))
+            {
+                xDirectionInput -= 1;
+            }
+            if (Input.GetKey(KeyCode.D))
+            {
+                xDirectionInput += 1;
+            }
         }
 
         targetXVelocity = xDirectionInput * maxSpeed;


### PR DESCRIPTION
Added a static bool receivePlayerMovementInput in PlayerRun. This bool tells player if they can receive inputs to move or not. Added in code with DialogManager under DialogueLock to update PlayerRun's static bool which decides if player's movement is locked or not.

Note: I myself don't know how to setup a scene to test out dialogue. So I technically don't know if this code will lock player movement with dialogue or not. Will require someone to test this properly. Can at least verify that player's right to receive movement inputs or not is indeed based on that static bool receivePlayerMovementInput.