### PR TITLE
Physics experimentation 2

### DIFF
--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -106,7 +106,7 @@ Rigidbody2D:
   m_Mass: 1
   m_LinearDrag: 0
   m_AngularDrag: 0.05
-  m_GravityScale: 1
+  m_GravityScale: 2.5
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -165,8 +165,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e5c71f7ad2d74fd588eec01013f5333, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxSpeed: 5
-  acceleration: 10
+  maxSpeed: 7.5
+  acceleration: 30
   decceleration: 40
 --- !u!114 &4913502350387851405
 MonoBehaviour:
@@ -183,7 +183,7 @@ MonoBehaviour:
   groundWallLayer:
     serializedVersion: 2
     m_Bits: 128
-  jumpPower: 450
+  jumpPower: 700
 --- !u!114 &6552423448974407449
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -197,7 +197,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   needle: {fileID: 0}
-  throwingForce: 350
+  throwingForce: 600
 --- !u!114 &4292287585466077967
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/PhysicsExperiment.unity
+++ b/Assets/Scenes/PhysicsExperiment.unity
@@ -1036,7 +1036,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1374604054293891926, guid: 3282a63fcd25643239289d63338dcbce, type: 3}
       propertyPath: acceleration
-      value: 15
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 4913502350387851405, guid: 3282a63fcd25643239289d63338dcbce, type: 3}
       propertyPath: jumpPower

--- a/Assets/Scenes/PhysicsExperiment2.unity
+++ b/Assets/Scenes/PhysicsExperiment2.unity
@@ -26985,28 +26985,12 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 1374604054293891926, guid: 3282a63fcd25643239289d63338dcbce, type: 3}
-      propertyPath: maxSpeed
-      value: 7.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1374604054293891926, guid: 3282a63fcd25643239289d63338dcbce, type: 3}
-      propertyPath: acceleration
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 1374604054293891926, guid: 3282a63fcd25643239289d63338dcbce, type: 3}
       propertyPath: decceleration
       value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 4292287585466077967, guid: 3282a63fcd25643239289d63338dcbce, type: 3}
       propertyPath: propelUnlocked
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4913502350387851405, guid: 3282a63fcd25643239289d63338dcbce, type: 3}
-      propertyPath: jumpPower
-      value: 700
-      objectReference: {fileID: 0}
-    - target: {fileID: 6552423448974407449, guid: 3282a63fcd25643239289d63338dcbce, type: 3}
-      propertyPath: throwingForce
-      value: 600
       objectReference: {fileID: 0}
     - target: {fileID: 7736974621993441411, guid: 3282a63fcd25643239289d63338dcbce, type: 3}
       propertyPath: m_LocalPosition.x
@@ -27047,10 +27031,6 @@ PrefabInstance:
     - target: {fileID: 7736974621993441411, guid: 3282a63fcd25643239289d63338dcbce, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7870602840530261809, guid: 3282a63fcd25643239289d63338dcbce, type: 3}
-      propertyPath: m_GravityScale
-      value: 2.5
       objectReference: {fileID: 0}
     - target: {fileID: 8920479047526667322, guid: 3282a63fcd25643239289d63338dcbce, type: 3}
       propertyPath: m_Name


### PR DESCRIPTION
Applied testing player movement values from Physics-Experiment-2 scene into the actual Player prefab.
Changes to Player Prefab include:

-increased horizontal max speed from 5 to 7.5
-raised gravityScale from 1 to 2.5 (faster falling)
-increased jump power from 450 to 700 (compensates for faster falling to overall have the same max jump height)
-increased throw power from 350 to 600
-horizontal acceleration raised from 10 to 30 (so that the rampup feels significantly faster)

Note: Could edit gravityScale & jumpPower more to reduce the feeling of floatiness. 
Note 2: Without the frictionless physics material applied to the walls/ground, the player is slower when moving alongside/against these objects. However, upon applying the frictionless material, the player is shown to be much slower at decelerating. Preparing the game world scenes with the frictionless material would imply I need to reconsider the player movement values as a whole (namely just the acceleration and decceleration values)
Note 3: The deceleration value does not seem to make much difference (could be improper implementation) and I seem to fail to differentiate deceleration when airborne/grounded.
Note 4: Not really related to the physics, but the one-way platforms currently block player from side (and the whole "pushing player out right after going down them" is disruptive). Need to take a look at one-way implementation again.