### PR TITLE
One-way-platform side-push-bug

### DIFF
--- a/Assets/Prefabs/Platforms/One-way Platform.prefab
+++ b/Assets/Prefabs/Platforms/One-way Platform.prefab
@@ -146,7 +146,7 @@ PlatformEffector2D:
   m_RotationalOffset: 0
   m_UseOneWay: 1
   m_UseOneWayGrouping: 0
-  m_SurfaceArc: 180
+  m_SurfaceArc: 179
   m_UseSideFriction: 0
   m_UseSideBounce: 0
   m_SideArc: 1

--- a/Assets/Scenes/PlatformTest.unity
+++ b/Assets/Scenes/PlatformTest.unity
@@ -149,7 +149,7 @@ Transform:
   m_GameObject: {fileID: 396734190}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -8.5, y: 0, z: 0}
+  m_LocalPosition: {x: -18.5, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 20, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -279,7 +279,7 @@ Transform:
   m_GameObject: {fileID: 574084119}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 8.5, y: 0, z: 0}
+  m_LocalPosition: {x: 18.5, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 20, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -509,6 +509,7 @@ Transform:
   - {fileID: 574084120}
   - {fileID: 837912847}
   - {fileID: 995990259}
+  - {fileID: 2024208576}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &782167835
@@ -799,7 +800,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: -3, z: 0}
-  m_LocalScale: {x: 16, y: 1, z: 1}
+  m_LocalScale: {x: 36, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 695702567}
@@ -906,6 +907,68 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2430384502117447584, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
   m_PrefabInstance: {fileID: 508427929595255470}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1395365160
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 695702567}
+    m_Modifications:
+    - target: {fileID: 2430384502117447584, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2430384502117447584, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2430384502117447584, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2430384502117447584, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2430384502117447584, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2430384502117447584, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2430384502117447584, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2430384502117447584, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2430384502117447584, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2430384502117447584, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8663519973897230745, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
+      propertyPath: m_Name
+      value: One-way Platform (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
+--- !u!4 &2024208576 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2430384502117447584, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
+  m_PrefabInstance: {fileID: 1395365160}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &508427929595255470
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -953,6 +1016,10 @@ PrefabInstance:
     - target: {fileID: 2430384502117447584, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4700547744840066230, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
+      propertyPath: m_SurfaceArc
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 8663519973897230745, guid: 9a6e6fa5e613d453593f3ae35d786149, type: 3}
       propertyPath: m_Name


### PR DESCRIPTION
In the one-way prefab, I fixed the bug where encountering one-way platform from the side would result in player being pushed back. The issue was the platform effector component's one-way surface arc being 180 degrees. This meant the collision of surface includes the left/right edges too. As a result, I reduced the surface arc by 1-degree to avoid the side-pushback from one-way platforms.

Note: This is a change made to the one-way platform prefab. It's likely that in the actual scenes, if we're not directly using that prefab, the editor needs to check on the one-way platform GameObject and manually change the platform effector component's one-way surface arc from 180 to 179 degrees.