### PR TITLE
One way platforms revisions 2

### DIFF
--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -18,6 +18,7 @@ GameObject:
   - component: {fileID: 4292287585466077967}
   - component: {fileID: 4604817687329902595}
   - component: {fileID: 7013419160347929015}
+  - component: {fileID: 2422462820588263765}
   m_Layer: 6
   m_Name: Player
   m_TagString: Player
@@ -247,3 +248,48 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!61 &2422462820588263765
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8920479047526667322}
+  m_Enabled: 0
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: -0.707}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1.5}
+    newSize: {x: 1, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.5, y: 0.03}
+  m_EdgeRadius: 0

--- a/Assets/Scripts/Player/PlayerJump.cs
+++ b/Assets/Scripts/Player/PlayerJump.cs
@@ -64,20 +64,35 @@ public class PlayerJump : MonoBehaviour
     public bool IsGrounded()
     {
 
-        
+
         //if (!Mathf.Approximately(rb.velocity.y, 0))
         //{
         //    return false;
         //}
 
-        Ray ray = new(col.bounds.center, Vector3.down);
+        //Note: Trying out alternate Raycasting method for more accurate conditions to jump
+        BoxCollider2D feetCollider = this.GetComponent<BoxCollider2D>();
+        if (feetCollider != null)
+        {
+            float raycastDistance = 0.01f; //shift the box X distance downwards for raycast
 
-        // A bit below the bottom
-        float fullDistance = col.bounds.extents.y + 0.05f - col.bounds.extents.x; // TODO: why is this here
+            Vector2 raycastStartingPosition = (Vector2)(feetCollider.transform.position) + feetCollider.offset;
 
-        //Note: did 95% of collider's size in case the side's are already touching walls
-        return Physics2D.CapsuleCast(this.transform.position, col.size * 0.95f, col.direction, 0, Vector2.down, fullDistance, groundWallLayer);
+            bool result = Physics2D.BoxCast(raycastStartingPosition, feetCollider.size, 0, Vector2.down, raycastDistance, groundWallLayer);
+            //Debug.Log("Using alternative method of raycasting which reports: " + result);
+            return result;
+        }
+        else //if we don't find the box collider needed for alternate Raycasting method, we'll do the original old method
+        {
 
+            Ray ray = new(col.bounds.center, Vector3.down);
+
+            // A bit below the bottom
+            float fullDistance = col.bounds.extents.y + 0.05f - col.bounds.extents.x; // TODO: why is this here
+
+            //Note: did 95% of collider's size in case the side's are already touching walls
+            return Physics2D.CapsuleCast(this.transform.position, col.size * 0.95f, col.direction, 0, Vector2.down, fullDistance, groundWallLayer);
+        }
         
     }
 }

--- a/Assets/Scripts/Player/PlayerJump.cs
+++ b/Assets/Scripts/Player/PlayerJump.cs
@@ -10,6 +10,8 @@ public class PlayerJump : MonoBehaviour
     Rigidbody2D rb;
     CapsuleCollider2D col;
 
+    BoxCollider2D feetCollider;
+
     PlayerNeedle playerNeedle;
 
     Animator animator;
@@ -19,6 +21,8 @@ public class PlayerJump : MonoBehaviour
     {
         rb = this.GetComponent<Rigidbody2D>();
         col = this.GetComponent<CapsuleCollider2D>();
+
+        feetCollider = this.GetComponent<BoxCollider2D>();
 
         playerNeedle = this.GetComponent<PlayerNeedle>();
         animator = this.GetComponent<Animator>();
@@ -71,7 +75,6 @@ public class PlayerJump : MonoBehaviour
         //}
 
         //Note: Trying out alternate Raycasting method for more accurate conditions to jump
-        BoxCollider2D feetCollider = this.GetComponent<BoxCollider2D>();
         if (feetCollider != null)
         {
             float raycastDistance = 0.01f; //shift the box X distance downwards for raycast

--- a/Assets/Scripts/Player/PlayerJump.cs
+++ b/Assets/Scripts/Player/PlayerJump.cs
@@ -43,9 +43,13 @@ public class PlayerJump : MonoBehaviour
             //if grounded, you can jump with spacebar
             if (Input.GetKeyDown(KeyCode.Space))
             {
-                //Note: I applied a force instead of editing the y velocity
+                
                 animator.SetTrigger("isJumping");
                 animator.SetBool("isGrounded", false);
+
+                //Note: I applied a force instead of editing the y velocity
+                //Note 2: Decided to reset y velocity before jumping because sometimes the y velocity isn't immediately 0 when grounded
+                rb.velocity = new Vector2(rb.velocity.x, 0);
                 rb.AddForce(Vector3.up * jumpPower);
                 
             }


### PR DESCRIPTION
Temp/Precautionary Solution:
Decided to reset y velocity before jumping because sometimes the y velocity isn't immediately 0 when grounded. Makes the jump boost look consistent

Alternate Raycasting for IsGrounded():
Edited IsGrounded() to try out alternate Raycasting method for more accurate conditions to jump. Instead of taking the entire capsule hitbox to raycast downwards, I added a box collider as the "feet" of the Player prefab (they're a small rectangle). When Raycasting, we raycast those rectangular "feet" slightly downwards to detect for Ground (instead of the entire capsule). I made to disable the box collider so it doesn't interfere with gameplay. This box collider just models as the player's feet and its individual values serve as reference for IsGrounded()'s new raycasting method.

Note: As a precaution, I had IsGrounded() use this alternate Raycasting method by default. If no BoxCollider is found under the player, then it uses the old Raycasting method.