### PR TITLE
Player Powerup Inventory Check

### DIFF
--- a/Assets/Scripts/Player/PlayerNeedle.cs
+++ b/Assets/Scripts/Player/PlayerNeedle.cs
@@ -51,7 +51,7 @@ public class PlayerNeedle : MonoBehaviour
         {
 
             //LMB to throw/recall needle depending on if needle is equipped or not
-            if (Input.GetKeyDown(KeyCode.Mouse0))
+            if (playerPowerupInventory.HasNeedleUnlocked() && Input.GetKeyDown(KeyCode.Mouse0))
             {
                 if (needleState.IsEquipped())
                 {

--- a/Assets/Scripts/Player/PlayerPowerupInventory.cs
+++ b/Assets/Scripts/Player/PlayerPowerupInventory.cs
@@ -32,6 +32,11 @@ public class PlayerPowerupInventory : MonoBehaviour
         
     }
 
+    public bool HasNeedleUnlocked()
+    {
+        return needleUnlocked;
+    }
+
     public bool HasPropelUnlocked()
     {
         return propelUnlocked;


### PR DESCRIPTION
Added check in PlayerNeedle so that player can only throw & recall needle if such a powerup is unlocked (from PlayerPowerupInventory).