### PR TITLE
TapSwitch - New implementation

### DIFF
--- a/Assets/Scripts/Switches/TapSwitch.cs
+++ b/Assets/Scripts/Switches/TapSwitch.cs
@@ -9,6 +9,8 @@ public class TapSwitch : Switch
 {
     public float switchTimer = 3.0f;
 
+    //TODO: this section of comments (w/IEnumerator) is the old implementation of TapSwitch with a cycle timer ("timer can't be reset until it's over")
+    /*
     private void OnTriggerEnter2D(Collider2D other)
     {
         //when trigger off and touched by knife or player, turn trigger on
@@ -34,10 +36,10 @@ public class TapSwitch : Switch
             }
         }
     }
+    */
 
     IEnumerator SwitchTriggered()
     {
-
         TurnOn();
 
         yield return new WaitForSeconds(switchTimer);
@@ -47,5 +49,47 @@ public class TapSwitch : Switch
         yield return null;
     }
 
+    //TODO: this section of code below is the new implementation of TapSwitch ("timer only counts down when player/knife leaves it")
+    //tracks if switch is touching anything (namely player or needle)
+    int numCollisions = 0;
+    Coroutine timerCoroutine = null;
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        //if not activated and touching player or knife, track the collision count
+        if (other.gameObject.layer.Equals(playerLayer) || other.gameObject.layer.Equals(needleLayer))
+        {
+            numCollisions += 1;
+        }
+    }
+
+    private void OnTriggerStay2D(Collider2D other)
+    {
+        //while touching player or knife, keep objects on
+        if (other.gameObject.layer.Equals(playerLayer) || other.gameObject.layer.Equals(needleLayer))
+        {
+            //stop timer and reset (turn all connected objects on)
+            if (timerCoroutine != null)
+            {
+                StopCoroutine(timerCoroutine);
+            }
+            TurnOn();
+        }
+
+    }
+
+    private void OnTriggerExit2D(Collider2D other)
+    {
+        //when player/needle leaves, start the timer for keeping connected objects on
+        if (other.gameObject.layer.Equals(playerLayer) || other.gameObject.layer.Equals(needleLayer))
+        {
+            numCollisions -= 1;
+
+            if (numCollisions == 0)
+            {
+                timerCoroutine = StartCoroutine(SwitchTriggered());
+            }
+        }
+    }
 
 }


### PR DESCRIPTION
Did new implementation for TapSwitch.
Originally the TapSwitch's timer only resets when it's over.
New implementation allows timer to reset while pressed (so it only starts counting down timer when released).

Note: This new implementation was already done before but for some reason on the day of SIOW game jam's submission, the TapSwitch script got reverted. This branch is just me copy & pasting the code in to repeat the steps again...